### PR TITLE
Introduce (optional) categories to group subcommands

### DIFF
--- a/application.go
+++ b/application.go
@@ -3,7 +3,6 @@ package climax
 import (
 	"fmt"
 	"os"
-	"strings"
 )
 
 // Application is a main CLI instance.
@@ -62,10 +61,8 @@ func (a *Application) AddCommand(command Command) {
 	a.Commands = append(a.Commands, command)
 
 	found := false
-	command.Category = strings.ToUpper(command.Category)
-
 	for idx, list := range a.Categories {
-		if strings.ToUpper(list[0].Category) == command.Category {
+		if list[0].Category == command.Category {
 			a.Categories[idx] = append(a.Categories[idx], command)
 			found = true
 			break

--- a/application.go
+++ b/application.go
@@ -18,13 +18,13 @@ type Application struct {
 
 	Commands   []Command
 	Topics     []Topic
-	Categories map[string][]Command
+	Categories [][]Command
 }
 
 func newApplication(name string) *Application {
 	return &Application{
 		Name:       name,
-		Categories: make(map[string][]Command),
+		Categories: make([][]Command, 0),
 	}
 }
 
@@ -61,11 +61,19 @@ func (a Application) isNameAvailable(name string) bool {
 func (a *Application) AddCommand(command Command) {
 	a.Commands = append(a.Commands, command)
 
-	category := strings.ToUpper(command.Category)
-	if _, ok := a.Categories[category]; !ok {
-		a.Categories[category] = []Command{command}
-	} else {
-		a.Categories[category] = append(a.Categories[category], command)
+	found := false
+	command.Category = strings.ToUpper(command.Category)
+
+	for idx, list := range a.Categories {
+		if strings.ToUpper(list[0].Category) == command.Category {
+			a.Categories[idx] = append(a.Categories[idx], command)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		a.Categories = append(a.Categories, []Command{command})
 	}
 }
 

--- a/application.go
+++ b/application.go
@@ -3,6 +3,7 @@ package climax
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // Application is a main CLI instance.
@@ -15,8 +16,16 @@ type Application struct {
 	Brief   string // `Go is a tool for managing Go source code.`
 	Version string // `1.5`
 
-	Commands []Command
-	Topics   []Topic
+	Commands   []Command
+	Topics     []Topic
+	Categories map[string][]Command
+}
+
+func newApplication(name string) *Application {
+	return &Application{
+		Name:       name,
+		Categories: make(map[string][]Command),
+	}
 }
 
 func (a *Application) commandByName(name string) *Command {
@@ -51,6 +60,13 @@ func (a Application) isNameAvailable(name string) bool {
 // AddCommand does literally what its name says.
 func (a *Application) AddCommand(command Command) {
 	a.Commands = append(a.Commands, command)
+
+	category := strings.ToUpper(command.Category)
+	if _, ok := a.Categories[category]; !ok {
+		a.Categories[category] = []Command{command}
+	} else {
+		a.Categories[category] = append(a.Categories[category], command)
+	}
 }
 
 // AddTopic does literally what its name says.

--- a/application.go
+++ b/application.go
@@ -22,7 +22,9 @@ type Application struct {
 	ungroupedCmdsCount int
 }
 
-// Group is smth
+// Group connects a list of commands with a descriptive string.
+//
+// The Name is used in the help output to group related commands together.
 type Group struct {
 	Name     string
 	Commands []*Command
@@ -67,7 +69,10 @@ func (a Application) isNameAvailable(name string) bool {
 	return true
 }
 
-// AddGroup adds a group.
+// AddGroup adds a new empty, named group.
+//
+// Pass the returned group name to Command's Group member
+// to make the command part of the group.
 func (a *Application) AddGroup(name string) string {
 	a.Groups = append(a.Groups, Group{Name: name})
 	return name

--- a/application_test.go
+++ b/application_test.go
@@ -10,7 +10,7 @@ func TestRun_Bare(t *testing.T) {
 		os.Args = []string{}
 		defer setArguments()
 
-		Application{}.Run()
+		newApplication("dummy").Run()
 	})
 }
 
@@ -46,7 +46,7 @@ The commands are:
 	attach      does some attaching
 	detach      detaches your mind
 	server      starts a web server
-
+	
 Use "application help [command]" for more information about a command.
 
 Additional help topics:
@@ -138,7 +138,7 @@ func TestRun_Help(t *testing.T) {
 }
 
 func TestAddCommand(t *testing.T) {
-	var a Application
+	a := newApplication("dummy")
 	a.AddCommand(Command{})
 	if len(a.Commands) != 1 {
 		t.Error("broken")
@@ -146,7 +146,7 @@ func TestAddCommand(t *testing.T) {
 }
 
 func TestAddTopic(t *testing.T) {
-	var a Application
+	a := newApplication("dummy")
 	a.AddTopic(Topic{})
 	if len(a.Topics) != 1 {
 		t.Error("broken")

--- a/application_test.go
+++ b/application_test.go
@@ -10,7 +10,7 @@ func TestRun_Bare(t *testing.T) {
 		os.Args = []string{}
 		defer setArguments()
 
-		newApplication("dummy").Run()
+		Application{}.Run()
 	})
 }
 
@@ -40,7 +40,7 @@ Usage:
 	application command [arguments]
 
 The commands are:
-
+	
 	open        opens smth
 	close       closes smth
 	attach      does some attaching
@@ -138,7 +138,7 @@ func TestRun_Help(t *testing.T) {
 }
 
 func TestAddCommand(t *testing.T) {
-	a := newApplication("dummy")
+	a := Application{}
 	a.AddCommand(Command{})
 	if len(a.Commands) != 1 {
 		t.Error("broken")
@@ -146,7 +146,7 @@ func TestAddCommand(t *testing.T) {
 }
 
 func TestAddTopic(t *testing.T) {
-	a := newApplication("dummy")
+	a := Application{}
 	a.AddTopic(Topic{})
 	if len(a.Topics) != 1 {
 		t.Error("broken")

--- a/climax.go
+++ b/climax.go
@@ -84,5 +84,5 @@ func New(name string) *Application {
 		panic("can't construct an app without a name")
 	}
 
-	return newApplication(name)
+	return &Application{Name: name}
 }

--- a/climax.go
+++ b/climax.go
@@ -84,5 +84,5 @@ func New(name string) *Application {
 		panic("can't construct an app without a name")
 	}
 
-	return &Application{Name: name}
+	return newApplication(name)
 }

--- a/command.go
+++ b/command.go
@@ -40,13 +40,8 @@ type Command struct {
 	// in the split terminal window.
 	Help string
 
-	// Category is an optional header that might be displayed
-	// over a block of commands. Commands with the the same
-	// Category share the same block.
-	//
-	// Example: "misc" commands would include: help, version, config
-	// Note that categories are uppercased automatically
-	Category string
+	// Group is smth.
+	Group string
 
 	// Handling, I bet it's pretty straight-forward.
 	Handle CmdHandler

--- a/command.go
+++ b/command.go
@@ -40,6 +40,14 @@ type Command struct {
 	// in the split terminal window.
 	Help string
 
+	// Category is an optional header that might be displayed
+	// over a block of commands. Commands with the the same
+	// Category share the same block.
+	//
+	// Example: "misc" commands would include: help, version, config
+	// Note that categories are uppercased automatically
+	Category string
+
 	// Handling, I bet it's pretty straight-forward.
 	Handle CmdHandler
 

--- a/command.go
+++ b/command.go
@@ -40,7 +40,7 @@ type Command struct {
 	// in the split terminal window.
 	Help string
 
-	// Group is smth.
+	// The group name this command belongs to.
 	Group string
 
 	// Handling, I bet it's pretty straight-forward.

--- a/help.go
+++ b/help.go
@@ -12,12 +12,12 @@ Usage:
 
 	{{.Name}} {{if .Commands}}command [arguments]{{end}}
 
-{{if .Commands}}The commands are:
+{{if .Commands}}{{if (index (index .Categories 0) 0).Category}}{{else}}The commands are:{{end}}
 
-{{range $category, $value := $.Categories}}
-{{if $category}}{{$category}} COMMANDS:{{end}}
+{{range $_, $commands := $.Categories}}
+{{ $cat := (index $commands 0).Category}}{{if $cat}}{{$cat}} COMMANDS:{{end}}
 
-	{{range $value}}{{.Name | printf "%-11s"}} {{.Brief}}
+	{{range $commands}}{{.Name | printf "%-11s"}} {{.Brief}}
 	{{end}}{{end}}
 Use "{{.Name}} help [command]" for more information about a command.{{end}}
 {{if .Topics}}

--- a/help.go
+++ b/help.go
@@ -15,7 +15,7 @@ Usage:
 {{if .Commands}}{{if (index (index .Categories 0) 0).Category}}{{else}}The commands are:{{end}}
 
 {{range $_, $commands := $.Categories}}
-{{ $cat := (index $commands 0).Category}}{{if $cat}}{{$cat}} COMMANDS:{{end}}
+{{ $cat := (index $commands 0).Category}}{{if $cat}}{{$cat}}:{{end}}
 
 	{{range $commands}}{{.Name | printf "%-11s"}} {{.Brief}}
 	{{end}}{{end}}

--- a/help.go
+++ b/help.go
@@ -12,12 +12,13 @@ Usage:
 
 	{{.Name}} {{if .Commands}}command [arguments]{{end}}
 
-{{if .Commands}}{{if (index (index .Categories 0) 0).Category}}{{else}}The commands are:{{end}}
-
-{{range $_, $commands := $.Categories}}
-{{ $cat := (index $commands 0).Category}}{{if $cat}}{{$cat}} COMMANDS:{{end}}
-
-	{{range $commands}}{{.Name | printf "%-11s"}} {{.Brief}}
+{{if .Commands}}The commands are:
+	{{if .UngroupedCount}}{{range .Commands}}
+	{{if not .Group}}{{.Name | printf "%-11s"}} {{.Brief}}{{end}}{{end}}
+	{{end}}{{range .Groups}}{{if .Commands}}
+{{.Name}}
+	{{range .Commands}}
+	{{.Name | printf "%-11s"}} {{.Brief}}{{end}}
 	{{end}}{{end}}
 Use "{{.Name}} help [command]" for more information about a command.{{end}}
 {{if .Topics}}
@@ -103,7 +104,13 @@ func flagUsage(flag Flag) string {
 }
 
 func (a *Application) globalHelp() string {
-	return templated(globalHelpTemplate, *a)
+	return templated(globalHelpTemplate, struct {
+		Application
+		UngroupedCount int
+	}{
+		*a,
+		a.ungroupedCmdsCount,
+	})
 }
 
 func (a *Application) commandHelp(command *Command) string {

--- a/help.go
+++ b/help.go
@@ -13,9 +13,12 @@ Usage:
 	{{.Name}} {{if .Commands}}command [arguments]{{end}}
 
 {{if .Commands}}The commands are:
-{{range .Commands}}
-	{{.Name | printf "%-11s"}} {{.Brief}}{{end}}
 
+{{range $category, $value := $.Categories}}
+{{if $category}}{{$category}} COMMANDS:{{end}}
+
+	{{range $value}}{{.Name | printf "%-11s"}} {{.Brief}}
+	{{end}}{{end}}
 Use "{{.Name}} help [command]" for more information about a command.{{end}}
 {{if .Topics}}
 Additional help topics:


### PR DESCRIPTION
For some larger programs it's sometimes useful to group commands into categories.
This patch should not alter normal output, but when filling out `Command.Category`,
it will be grouped accordingly.

Here's an example from ipfs:

``` USAGE:

    ipfs - global p2p merkle-dag filesystem

    ipfs [<flags>] <command> [<arg>] ...

    BASIC COMMANDS

        init          Initialize ipfs local configuration
        add <path>    Add an object to ipfs
        cat <ref>     Show ipfs object data
        get <ref>     Download ipfs objects
        ls <ref>      List links from an object
        refs <ref>    List hashes of links from an object

    DATA STRUCTURE COMMANDS

        block         Interact with raw blocks in the datastore
        object        Interact with raw dag nodes
        file          Interact with Unix filesystem objects

    ADVANCED COMMANDS

        daemon        Start a long-running daemon process
        mount         Mount an ipfs read-only mountpoint
        resolve       Resolve any type of name
        name          Publish or resolve IPNS names
        dns           Resolve DNS links
        pin           Pin objects to local storage
        repo gc       Garbage collect unpinned objects

    NETWORK COMMANDS

        id            Show info about ipfs peers
        bootstrap     Add or remove bootstrap peers
        swarm         Manage connections to the p2p network
        dht           Query the dht for values or peers
        ping          Measure the latency of a connection
        diag          Print diagnostics

    TOOL COMMANDS

        config        Manage configuration
        version       Show ipfs version information
        update        Download and apply go-ipfs updates
        commands      List all available commands
```
